### PR TITLE
[Feature]增加插件重装功能，优化插件卸载提示。

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -474,6 +474,7 @@ class Admin
         app()->route->post('plug/enable', Plug::class . '@enable');
         app()->route->post('plug/install', Plug::class . '@install');
         app()->route->post('plug/uninstall', Plug::class . '@uninstall');
+        app()->route->post('plug/reInstall', Plug::class . '@reInstall');
         app()->route->post('plug/refreshAuthorization', Plug::class . '@refreshAuthorization');
         app()->route->get('plug', Plug::class . '@index');
 

--- a/src/controller/Plug.php
+++ b/src/controller/Plug.php
@@ -151,11 +151,18 @@ class Plug extends Controller
                         Button::create('启用')->sizeSmall()->typeSuccess()->save(['id' => $rows['name'], 'status' => 1], 'plug/enable', '确认启用？')
                     );
                 }
+
+                $actions->append(
+                    Button::create('重装')
+                        ->sizeSmall()
+                        ->typeWarning()
+                        ->save(['name' => $rows['name']], 'plug/reInstall', '确认重新安装【'.$rows['title'].'】吗？此操作将清空插件所有数据！')
+                );
                 $actions->append(
                     Button::create('卸载')
                         ->sizeSmall()
                         ->typeDanger()
-                        ->save(['name' => $rows['name']], 'plug/uninstall', '确认卸载？')
+                        ->save(['name' => $rows['name']], 'plug/uninstall', '确认卸载【'.$rows['title'].'】吗？此操作将清空数据并且删除插件对应的所有文件！')
                 );
             } else {
                 if($rows['is_buy']){
@@ -274,7 +281,17 @@ class Plug extends Controller
         admin_success_message('卸载完成')->refreshMenu()->refresh();
     }
 
-
+     /**
+     * 重新安装
+     * @auth false
+     * @login true
+     */
+    public function reInstall()
+    {
+        $name = $this->request->put('name');
+        Admin::plug()->reInstall($name);
+        admin_success_message('已重新安装')->refreshMenu()->refresh();
+    }
 
     /**
      * 创建扩展


### PR DESCRIPTION
主要增加插件的重装功能，场景：

刚创建好插件默认就安装好了，菜单、数据迁移、数据填充都还没有生成，如果直接在插件目录下开发，无法执行创建菜单、迁移数据、填充数据等操作，增加这个功能，可以减少手动执行数据迁移、数据填充的操作。

另外优化了一下卸载插件的提示，这个卸载操作非常危险，稍有不慎就会产生误操作， 另外卸载插件时同时把关联插件也卸载掉这个功能感觉还是有点不太友好，改天单开issue讨论。

非常感谢 🤝 。